### PR TITLE
consider 600dp and above as a tablet

### DIFF
--- a/Style/FormFactors.ux
+++ b/Style/FormFactors.ux
@@ -1,7 +1,7 @@
 <Panel ux:Class="Material.FormFactors">
 
 	<!-- Is active while the device is considered a tablet device in material design -->
-	<WhileWindowSize ux:Class="Material.WhileTablet" GreaterThan="720,1">
+	<WhileWindowSize ux:Class="Material.WhileTablet" GreaterThan="599,1">
 
 	</WhileWindowSize>
 


### PR DESCRIPTION
Google lists 600 dp as the size of a 7" tablet:

https://developer.android.com/guide/practices/screens_support.html#DeclaringTabletLayouts

So let's just follow their example. This is rather arbitrary, but
at least this is coming from the authorative source ;)